### PR TITLE
Clamp qty to Binance lot size

### DIFF
--- a/configs/live_cfg.yaml
+++ b/configs/live_cfg.yaml
@@ -1,6 +1,7 @@
 symbol: BTCUSDT
 interval: 1m
 leverage: 3
+# Binance minimum size for BTC is 0.001 BTC (~30 USDT at $30k)
 usd_per_trade: 10.0
 starting_equity: 1000.0
 log_dir: live_logs

--- a/live/broker.py
+++ b/live/broker.py
@@ -90,7 +90,9 @@ class Broker:
             except Exception:
                 pass
         qty = usd / price
-        return float(f"{qty:.3f}")
+        # Round to six decimals and clamp to Binance minimum lot size
+        qty = max(qty, 0.001)
+        return float(f"{qty:.6f}")
 
     # ------------------------------------------------------------------
 

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -22,3 +22,14 @@ def test_open_close_dryrun(monkeypatch):
     assert open_resp["side"] == "BUY"
     close_resp = b.close_position()
     assert close_resp["side"] == "SELL"
+
+
+def test_calc_qty_minimum(monkeypatch):
+    monkeypatch.setattr(br, "Client", lambda k, s: DummyClient())
+    monkeypatch.setattr(br, "load_keys", lambda: ("k", "s"))
+    cfg = BrokerConfig(
+        "BTCUSDT", 1, dry_run=True, starting_equity=100, usd_per_trade=10
+    )
+    b = Broker(cfg)
+    qty = b._calc_qty(price=1_000_000)
+    assert qty > 0


### PR DESCRIPTION
## Summary
- clamp `_calc_qty` to a minimum lot size and keep six decimal precision
- test quantity calculation on very high prices
- note minimum BTC lot in `live_cfg.yaml`

## Testing
- `pytest tests/test_broker.py::test_open_close_dryrun tests/test_broker.py::test_calc_qty_minimum -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68540eaf8aa0832eaa0a7081f2918c9c